### PR TITLE
Improves error handling

### DIFF
--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -4,6 +4,7 @@ import six
 from django.forms import HiddenInput
 from django.utils.html import format_html
 from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos.point import Point
 from django.utils.safestring import mark_safe
 
 from wagtailgeowidget.app_settings import (
@@ -50,6 +51,12 @@ class GeoField(HiddenInput):
 
         if value and isinstance(value, six.string_types):
             value = GEOSGeometry(value)
+            data['defaultLocation'] = {
+                'lat': value.y,
+                'lng': value.x,
+            }
+
+        if value and isinstance(value, Point):
             data['defaultLocation'] = {
                 'lat': value.y,
                 'lng': value.x,


### PR DESCRIPTION
Sloppy typing can result in stacked alerts which can be a pretty large annoyance, and wagtail already has some conventions for error states of inputs. This utilizes those conventions to indicate to a user that they may want to correct their Address if it cannot be geo-coded. 