### PR TITLE
Fixed 'too much recursion' error when the coordinates in the input are invalid.

### DIFF
--- a/wagtailgeowidget/static/wagtailgeowidget/js/geo-field.js
+++ b/wagtailgeowidget/static/wagtailgeowidget/js/geo-field.js
@@ -209,6 +209,14 @@ GeoField.prototype.updateMapFromCoords = function(coords) {
 }
 
 GeoField.prototype.setMapPosition = function(latLng) {
+    // If lat or lng is not a number (this can happen when the coordinates input is being modified), the Maps
+    // API enters in a recursion cycle crashing the browser
+    if (isNaN(latLng.lat()) || isNaN(latLng.lng())) {
+        this.sourceField.val("");
+
+        return;
+    }
+
     this.marker.setPosition(latLng);
     this.map.setCenter(latLng);
 }


### PR DESCRIPTION
When editing the coordinates text input if the comma is removed or there is an invalid value on either side, the `updateMapFromCoords` it is passed to the map a LatLng with NaN as lat or lng which makes the browser crash with a 'too much recursion' error. This PR fixes this problem by validating if the lat and lng are valid. If they're not, the marker and map stay in the same position and the hidden input value is reset.
The flow chosen for this was the same as when the panel is created on a new model, so if the coordinates in the text input are invalid (even though the marker is still visible and in the last valid location) there will be a validation error on save.