### PR TITLE
Correctly handle not having gis installed

### DIFF
--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -8,7 +8,7 @@ from django.utils.safestring import mark_safe
 try:
     from django.contrib.gis.geos.point import Point
 except:
-    pass
+    Point = None
 
 from wagtailgeowidget.helpers import geosgeometry_str_to_struct
 from wagtailgeowidget.app_settings import (
@@ -82,7 +82,7 @@ class GeoField(HiddenInput):
                     'lng': result['x'],
                 }
 
-        if value and isinstance(value, Point):
+        if value and Point and isinstance(value, Point):
             data['defaultLocation'] = {
                 'lat': value.y,
                 'lng': value.x,


### PR DESCRIPTION
When we handle not being able to import the gis Point type when gis is
not installed we don't set up any value for the Point variable. This
means later when we try and test type it is not defined and we get a
NameError.

Set Point to None and test if it is set later.