### PR TITLE
Sync between latLngField and hidden input with coordinates

### DIFF
--- a/wagtailgeowidget/static/wagtailgeowidget/js/geo-field.js
+++ b/wagtailgeowidget/static/wagtailgeowidget/js/geo-field.js
@@ -73,6 +73,7 @@ GeoField.prototype.initEvents = function() {
 
         self.clearFieldMessage({field: self.latLngField});
         self.updateMapFromCoords(latLng);
+        self.writeLocation(latLng);
     });
 
     this.addressField.on("keydown", function(e) {


### PR DESCRIPTION
This pr fixes consistency problems when the latlng input is changed as the coordinates in the hidden input are only overwritten when the marker is dragged. This can be misleading for editors that use the input to change/paste coordinates instead of dragging the marker because in spite of the marker moving to the right coordinates the old ones are still in the hidden input and are the ones that are saved. With this when the user inputs valid coordinates, those are written in the hidden input.