### PR TITLE
Added template tag for rendering:

### DIFF
--- a/wagtailgeowidget/__init__.py
+++ b/wagtailgeowidget/__init__.py
@@ -7,8 +7,8 @@ wagtailgeowidget
 A Google Maps widget for Wagtail that supports both GeoDjango PointField, StreamField and the standard CharField.
 """
 __title__ = "wagtailgeowidget"
-__version__ = "3.1.5"
-__build__ = 315
+__version__ = "3.1.8"
+__build__ = 318
 __author__ = "Martin Sandström"
 __license__ = "MIT"
 __copyright__ = "Copyright 2015-2017 Fröjd Interactive"

--- a/wagtailgeowidget/templatetags/wagtailgeowidget_tags.py
+++ b/wagtailgeowidget/templatetags/wagtailgeowidget_tags.py
@@ -1,0 +1,43 @@
+from django.template import Library
+from django.utils.safestring import mark_safe
+
+from wagtailgeowidget.app_settings import (
+    GEO_WIDGET_DEFAULT_LOCATION,
+    GEO_WIDGET_ZOOM,
+    GOOGLE_MAPS_V3_APIKEY,
+)
+
+register = Library()
+
+
+@register.simple_tag
+def render_map(map, style):
+    return mark_safe(
+        '<div class={} id={}></div>'.format(style, map['srid']) +
+        """
+        <script>
+            function initMap() {{
+                var point = {{lat: {}, lng: {}}};
+                var map = new google.maps.Map(document.getElementById('{}'), {{
+                    zoom: {},
+                    center: point
+                }});
+                var marker = new google.maps.Marker({{
+                    position: point,
+                    map: map
+                }});
+            }}
+        </script>
+        """.format(
+            map['lat'],
+            map['lng'],
+            map['srid'],
+            GEO_WIDGET_ZOOM
+        ) +
+        """
+            <script async defer src="https://maps.googleapis.com/maps/api/js?key={}&callback=initMap">
+            </script>
+        """.format(
+            GOOGLE_MAPS_V3_APIKEY,
+        )
+    )


### PR DESCRIPTION
It's very simple but it works:
```html
{% load i18n wagtailgeowidget_tags %}
<div>
    {% render_map self.map 'map' %}
    <p><strong>{% trans 'Address' %}:</strong> {{ self.address }}</p>
</div>
```

i have only a problem with it: it must have to have a class name, if you don't pass a class name as second value, it will give you a error.

Actually this class could be needed because styling is needed for the container, but, maybe this requierement could be not good.