### PR TITLE
Drop use of parse_requirements due to pip 10 incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,7 @@ import io
 import os
 import sys
 import re
-import pip
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
 
 if sys.argv[-1] == "publish":
@@ -17,11 +15,6 @@ if sys.argv[-1] == "publish":
 
 with open('README.md') as f:
     readme = f.read()
-
-# Handle requirements
-requires = parse_requirements("requirements/install.txt",
-                              session=pip.download.PipSession())
-install_requires = [str(ir.req) for ir in requires]
 
 # Convert markdown to rst
 try:
@@ -45,7 +38,9 @@ setup(
     url="https://github.com/frojd/wagtail-geo-widget",
     packages=find_packages(exclude=('tests*',)),
     include_package_data=True,
-    install_requires=install_requires,
+    install_requires=[
+        'Django>=1.11',
+    ],
     license="MIT",
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
With `pip==10` `parse_requirements` has moved to `pip._internals.req`, which makes installing this package throw an `ImportError`.

Whilst it would be possible to continue using the function in its new location, parsing requirements in `setup.py` is [not a good practice](https://github.com/pypa/pip/issues/2286#issuecomment-68285791) and the move to `_internals` reflects that.

The alternatives are to maintain the requirement in two places, or to install `.` in `requirements.txt`