### PR TITLE
Add renderer argument to GeoField.render() method

### DIFF
--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -46,8 +46,11 @@ class GeoField(HiddenInput):
             ),
         )
 
-    def render(self, name, value, attrs=None):
-        out = super(GeoField, self).render(name, value, attrs)
+    def render(self, name, value, attrs=None, renderer=None):
+        out = super(GeoField, self).render(name,
+                                           value,
+                                           attrs=attrs,
+                                           renderer=renderer)
 
         location = format_html(
             '<div class="input">'


### PR DESCRIPTION
Support for Widget.render() methods without the renderer argument is
removed in Django 2.1.