### PR TITLE
Fix location string parsing regex in JS to allow for space before point field brackets.

### DIFF
--- a/wagtailgeowidget/static/wagtailgeowidget/js/geo-field.js
+++ b/wagtailgeowidget/static/wagtailgeowidget/js/geo-field.js
@@ -268,7 +268,7 @@ GeoField.locationStringToStruct = function(locationString) {
     }
 
     var matches = locationString.match(
-        /^SRID=([0-9]{1,});POINT\((-?[0-9\.]{1,})\s(-?[0-9\.]{1,})\)$/
+        /^SRID=([0-9]{1,});POINT\s?\((-?[0-9\.]{1,})\s(-?[0-9\.]{1,})\)$/
     )
 
     return {


### PR DESCRIPTION
Hi there!

The `GeoPanel` doesn't currently work with GeoDjango `PointField`s because of a small difference in how the string representation of the value is rendered. Django renders a `PointField` like so:

```
SRID=4326;POINT (36.803684 -1.271821)
```

There is a space after `POINT` and before the opening bracket.

The JS currently expects no space (`POINT(36.803684 -1.271821)`), and so parsing of the field fails. This patch modifies the regex to allow an optional space.