### PR TITLE
Added if check for translation fix if above 4.0

### DIFF
--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -5,7 +5,10 @@ from django.forms import widgets
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+if django.VERSION < (4, 0):
+    from django.utils.translation import ugettext as _
+else:
+    from django.utils.translation import gettext as _
 from wagtail.core.telepath import register
 from wagtail.core.widget_adapters import WidgetAdapter
 from wagtail.utils.widgets import WidgetWithScript


### PR DESCRIPTION
In Django 4.0 ugettext is deprecated. (As django is not python2 supported anymore)
Link to ticket in django: https://code.djangoproject.com/ticket/30165

Fixed with just renaming it to "gettext" in widgets.py.