### PR TITLE
Added if check for translation fix if above 4.0

### DIFF
--- a/docs/adding-to-a-page.md
+++ b/docs/adding-to-a-page.md
@@ -86,7 +86,7 @@ The address field are optional and needs to be added separately, the panel accep
 
 ```python
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtailgeowidget import geocoders
 from wagtailgeowidget.edit_handlers import GeoAddressPanel, GoogleMapsPanel
@@ -112,7 +112,7 @@ The zoom field works in a similar way as the address field and needs to be added
 
 ```python
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtailgeowidget.edit_handlers import GoogleMapsPanel
 

--- a/docs/integrating-with-geodjango.md
+++ b/docs/integrating-with-geodjango.md
@@ -24,7 +24,7 @@ The panel accepts an `address_field` if you want to use the map in coordination 
 
 ```python
 from django.contrib.gis.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtailgeowidget import geocoders
 from wagtailgeowidget.edit_handlers import GeoAddressPanel, GoogleMapsPanel
@@ -49,7 +49,7 @@ The panel accepts an `zoom_field` if you want to persist the zoom state.
 
 ```python
 from django.contrib.gis.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from wagtailgeowidget.edit_handlers import GoogleMapsPanel
 

--- a/example/geopage/models.py
+++ b/example/geopage/models.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.gis.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
     FieldPanel,

--- a/example/geopage_nospatial/models.py
+++ b/example/geopage_nospatial/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, StreamFieldPanel
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField

--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -5,7 +5,7 @@ from django.forms import widgets
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.core.telepath import register
 from wagtail.core.widget_adapters import WidgetAdapter
 from wagtail.utils.widgets import WidgetWithScript


### PR DESCRIPTION
In Django 4.0 ugettext is deprecated. (As django is not python2 supported anymore)
Link to ticket in django: https://code.djangoproject.com/ticket/30165

Replaced with gettext, rebranched to develop as requested. Also updated all points that reference using ugettext.