### PR TITLE
Ensure setup() is only called after user focus if showEmptyLocation is true

### DIFF
--- a/wagtailgeowidget/static/wagtailgeowidget/js/leaflet-field.js
+++ b/wagtailgeowidget/static/wagtailgeowidget/js/leaflet-field.js
@@ -45,8 +45,6 @@ function LeafletField(options) {
     } else {
         this.setup();
     }
-
-    this.setup();
 }
 
 LeafletField.prototype.setup = function () {


### PR DESCRIPTION
This fixes early map setup in case `showEmptyLocation` is set.

The code was already handling the activation of the the map element when the latLngField was focused. But as it always called `this.setup()` on init the latLngField was already populated with the default location and the placeholder not shown to users.

Note that `this.setup()` is correctly called immediately if `showEmptyLocation` is false on the `else` case above