### PR TITLE
Fixing edit_handlers.py for wagtail 4 (new permission option on fieldpanels not working)

### DIFF
--- a/wagtailgeowidget/edit_handlers.py
+++ b/wagtailgeowidget/edit_handlers.py
@@ -43,12 +43,11 @@ class GoogleMapsPanel(FieldPanel):
 
     def clone(self):
         return self.__class__(
-            field_name=self.field_name,
-            classname=self.classname,
             address_field=self.address_field,
             zoom_field=self.zoom_field,
             hide_latlng=self.hide_latlng,
             zoom=self.zoom,
+            **self.clone_kwargs()
         )
 
 
@@ -84,8 +83,8 @@ class GeoAddressPanel(FieldPanel):
 
     def clone(self):
         return self.__class__(
-            field_name=self.field_name,
             geocoder=self.geocoder,
+            **self.clone_kwargs()
         )
 
 
@@ -121,10 +120,9 @@ class LeafletPanel(FieldPanel):
 
     def clone(self):
         return self.__class__(
-            field_name=self.field_name,
-            classname=self.classname,
             address_field=self.address_field,
             zoom_field=self.zoom_field,
             hide_latlng=self.hide_latlng,
             zoom=self.zoom,
+            **self.clone_kwargs()
         )

--- a/wagtailgeowidget/edit_handlers.py
+++ b/wagtailgeowidget/edit_handlers.py
@@ -82,10 +82,7 @@ class GeoAddressPanel(FieldPanel):
         }
 
     def clone(self):
-        return self.__class__(
-            geocoder=self.geocoder,
-            **self.clone_kwargs()
-        )
+        return self.__class__(geocoder=self.geocoder, **self.clone_kwargs())
 
 
 class LeafletPanel(FieldPanel):


### PR DESCRIPTION
A wrong override of clone method shadows additional keyword arguments like the new "permission" option in Wagtail 4