### PR TITLE
Wagtail 4.2 upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
           - 3.0.3
           - 4.0.4
           - 4.1.1
+          - 4.2.rc1
         exclude:
           - python-version: "3.11"
             wagtail-version: "2.15.5"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - 3.0.3
           - 4.0.4
           - 4.1.1
-          - 4.2.rc1
+          - 4.2
         exclude:
           - python-version: "3.11"
             wagtail-version: "2.15.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 ### Changed
 ### Fixed
+- Add Wagtail 4.2 compability (@marteinn)
 ### Removed
 
 ## [7.0.0] - 2022.12.03

--- a/tests/home/migrations/0001_initial.py
+++ b/tests/home/migrations/0001_initial.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [


### PR DESCRIPTION
Release notes: https://docs.wagtail.org/en/stable/releases/4.2.html

- Dropped support for Wagtail versions < 4.1
- Code cleanup

Tests are OK

```
Found 14 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..............
----------------------------------------------------------------------
Ran 14 tests in 0.130s

OK
```