### PR TITLE
Add support for Mapbox language parameter

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,3 +20,4 @@
 - `GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS`: The tile layer options for leaflet, it supports [the following arguments](https://leafletjs.com/reference.html). Default is `{"attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}`
 
 - `MAPBOX_ACCESS_TOKEN`: Access token fpr Mapbox Geocoding API. Defaults to None.
+- `MAPBOX_LANGUAGE`: [Language parameter](https://docs.mapbox.com/api/search/geocoding/#forward-geocoding) for Mapbox Geocoding API. Defaults to `en`. 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -54,6 +54,7 @@ class LeafletFieldTestCase(TestCase):
 class GeocoderFieldTestCase(TestCase):
     def setUp(self):
         app_settings.MAPBOX_ACCESS_TOKEN = None
+        app_settings.MAPBOX_LANGUAGE = "en"
 
     def test_geocoder_field_contains_constuct_regular(self):
         widget = GeocoderField()
@@ -96,3 +97,10 @@ class GeocoderFieldTestCase(TestCase):
         self.assertIn('accessToken": "<MAPBOX ACCESS TOKEN>', html)
 
         app_settings.MAPBOX_ACCESS_TOKEN = None
+    
+    def test_mapbox_language_parameter_gets_outputted(self):
+        widget = GeocoderField(geocoder=geocoders.MAPBOX)
+        html = widget.render_js_init("id", "field", "")
+
+        self.assertIn("new MapboxGeocoderField", html)
+        self.assertIn('language": "en', html)

--- a/wagtailgeowidget/app_settings.py
+++ b/wagtailgeowidget/app_settings.py
@@ -26,3 +26,4 @@ GOOGLE_MAPS_V3_APIKEY_CALLBACK = getattr(
 GOOGLE_MAPS_V3_LANGUAGE = getattr(settings, "GOOGLE_MAPS_V3_LANGUAGE", "en")
 
 MAPBOX_ACCESS_TOKEN = getattr(settings, "MAPBOX_ACCESS_TOKEN", None)
+MAPBOX_LANGUAGE = getattr(settings, "MAPBOX_LANGUAGE", "en")

--- a/wagtailgeowidget/static/wagtailgeowidget/js/geocoder-field.js
+++ b/wagtailgeowidget/static/wagtailgeowidget/js/geocoder-field.js
@@ -212,6 +212,7 @@ function MapboxGeocoderField(options) {
     var params = options.params || {};
 
     this.accessToken = params.accessToken;
+    this.language = params.language;
 }
 
 MapboxGeocoderField.prototype = Object.create(GeocoderField.prototype);
@@ -227,6 +228,7 @@ MapboxGeocoderField.prototype.geocodeSearch = function (query) {
         new URLSearchParams({
             limit: 1,
             access_token: this.accessToken,
+            language: this.language,
         });
 
     fetch(url)

--- a/wagtailgeowidget/widgets.py
+++ b/wagtailgeowidget/widgets.py
@@ -272,9 +272,13 @@ class GeocoderField(WidgetWithScript, widgets.TextInput):
         options = {"id": id_, "translations": translations}
         params = {}
         if self.geocoder == geocoders.MAPBOX:
-            from wagtailgeowidget.app_settings import MAPBOX_ACCESS_TOKEN
+            from wagtailgeowidget.app_settings import (
+                MAPBOX_ACCESS_TOKEN,
+                MAPBOX_LANGUAGE,
+            )
 
             params["accessToken"] = MAPBOX_ACCESS_TOKEN
+            params["language"] = MAPBOX_LANGUAGE
 
         options["params"] = params
 


### PR DESCRIPTION
Hello,

Mapbox Geocoding API has a language parameter that affects result scoring (see https://docs.mapbox.com/api/search/geocoding/#forward-geocoding). This PR adds a language setting that defaults to `en`.

I added a simple test and updated the documentation.