### PR TITLE
fix regex `SyntaxWarning` in Python 3.12

### DIFF
--- a/wagtailgeowidget/helpers.py
+++ b/wagtailgeowidget/helpers.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict
 
 geos_ptrn = re.compile(
-    "^SRID=([0-9]{1,});POINT\s?\((-?[0-9\.]{1,})\s(-?[0-9\.]{1,})\)$"
+    r"^SRID=([0-9]{1,});POINT\s?\((-?[0-9\.]{1,})\s(-?[0-9\.]{1,})\)$"
 )
 
 


### PR DESCRIPTION
This fixes the following warning message from being printed with Python 3.12:

```
SyntaxWarning: invalid escape sequence '\s'
  "^SRID=([0-9]{1,});POINT\s?\((-?[0-9\.]{1,})\s(-?[0-9\.]{1,})\)$"
```