### PR TITLE
Set a default referrerPolicy for leaflet tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 ### Changed
 ### Fixed
+- Set a default `referrerPolicy` in `GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS` to prevent OpenStreetMap tile servers rejecting requests (@tomkins)
+
 ### Removed
 
 ## [9.1.0] - 2025.11.09

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,7 +17,7 @@
     ```
 
 - `GEO_WIDGET_LEAFLET_TILE_LAYER`: Which title provider to use in Leaflet. By default it is OSM. (`https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`).
-- `GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS`: The tile layer options for leaflet, it supports [the following arguments](https://leafletjs.com/reference.html). Default is `{"attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}`
+- `GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS`: The tile layer options for leaflet, it supports [the following arguments](https://leafletjs.com/reference.html). Default is `{"referrerPolicy": "strict-origin-when-cross-origin", "attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}`
 
 - `MAPBOX_ACCESS_TOKEN`: Access token fpr Mapbox Geocoding API. Defaults to None.
 - `MAPBOX_LANGUAGE`: [Language parameter](https://docs.mapbox.com/api/search/geocoding/#forward-geocoding) for Mapbox Geocoding API. Defaults to `en`. 

--- a/wagtailgeowidget/app_settings.py
+++ b/wagtailgeowidget/app_settings.py
@@ -15,7 +15,8 @@ GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS = getattr(
     settings,
     "GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS",
     {
-        "attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
 )
 


### PR DESCRIPTION
Closes #137 

To test:
- Add a `LeafletPanel` to the admin
- Inspect network requests
- Check that Referrer Policy is `strict-origin-when-cross-origin`, and a Referer header is sent

<img width="569" height="165" alt="Screenshot 2026-03-25 at 21 45 08" src="https://github.com/user-attachments/assets/f6b56471-8c54-4ff1-a21e-f393a6f961b9" />
