### PR TITLE
Use tile.openstreetmap.org for OpenStreetMap tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 ### Changed
 ### Fixed
+- Update `GEO_WIDGET_LEAFLET_TILE_LAYER` to use tile.openstreetmap.org for OpenStreetMap tiles (@tomkins)
+
 ### Removed
 
 ## [9.1.0] - 2025.11.09

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -16,7 +16,7 @@
         return settings.google_maps_apikey
     ```
 
-- `GEO_WIDGET_LEAFLET_TILE_LAYER`: Which title provider to use in Leaflet. By default it is OSM. (`https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`).
+- `GEO_WIDGET_LEAFLET_TILE_LAYER`: Which title provider to use in Leaflet. By default it is OSM. (`https://tile.openstreetmap.org/{z}/{x}/{y}.png`).
 - `GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS`: The tile layer options for leaflet, it supports [the following arguments](https://leafletjs.com/reference.html). Default is `{"attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}`
 
 - `MAPBOX_ACCESS_TOKEN`: Access token fpr Mapbox Geocoding API. Defaults to None.

--- a/wagtailgeowidget/app_settings.py
+++ b/wagtailgeowidget/app_settings.py
@@ -9,7 +9,7 @@ GEO_WIDGET_ZOOM = getattr(settings, "GEO_WIDGET_ZOOM", 7)
 GEO_WIDGET_LEAFLET_TILE_LAYER = getattr(
     settings,
     "GEO_WIDGET_LEAFLET_TILE_LAYER",
-    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
 )
 GEO_WIDGET_LEAFLET_TILE_LAYER_OPTIONS = getattr(
     settings,


### PR DESCRIPTION
Closes #139 

To test:
- Add a `LeafletPanel` to the admin
- Inspect network requests
- Check that requested tile images are from `tile.openstreetmap.org`

<img width="540" height="144" alt="Screenshot 2026-03-25 at 22 23 26" src="https://github.com/user-attachments/assets/1de38b49-8a94-4b42-9662-acf81187ef1b" />
