### PR TITLE
Wagtail 7.4 maintenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           options: "--check --verbose"
           src: "."
-          version: "22.3.0"
+          version: "25.1.0"
 
   lint-isort:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,38 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        wagtail-version: ["6.3", "7.0", "7.1", "7.2"]
-        django-version: ["4.2", "5.1", "5.2"]
+        wagtail-version: ["7.0", "7.2", "7.3", "7.4"]
+        django-version: ["4.2", "5.1", "5.2", "6.0"]
         exclude:
-          - python-version: "3.13"
+          # Django 4.2 does not support Python 3.14
+          - python-version: "3.14"
             django-version: "4.2"
-          - python-version: "3.13"
-            django-version: "5.0"
+          # Django 5.1 does not support Python 3.14
+          - python-version: "3.14"
+            django-version: "5.1"
+          # Django 6.0 requires Python 3.12+
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
+          # Wagtail 7.0 supports Django 4.2, 5.1, 5.2 and Python 3.10-3.13
+          - wagtail-version: "7.0"
+            django-version: "6.0"
+          - wagtail-version: "7.0"
+            python-version: "3.14"
+          # Wagtail 7.2 supports Django 4.2, 5.1, 5.2 and Python 3.10-3.13
+          - wagtail-version: "7.2"
+            django-version: "6.0"
+          - wagtail-version: "7.2"
+            python-version: "3.14"
+          # Wagtail 7.3 supports Django 4.2, 5.2, 6.0
+          - wagtail-version: "7.3"
+            django-version: "5.1"
+          # Wagtail 7.4 supports Django 5.2, 6.0
+          - wagtail-version: "7.4"
+            django-version: "4.2"
+          - wagtail-version: "7.4"
+            django-version: "5.1"
     services:
       postgres:
         image: postgis/postgis:15-3.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test]
           pip install psycopg2-binary>=2.9.3
-      - name: Install wagtail ${{ matrix.wagtail-version }}
-        run: pip install wagtail==${{ matrix.wagtail-version }}
+      - name: Install Django ${{ matrix.django-version }} and Wagtail ${{ matrix.wagtail-version }}
+        run: pip install "Django~=${{ matrix.django-version }}.0" "wagtail==${{ matrix.wagtail-version }}"
       - name: Run tests
         run: |
           pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased]
 ### Added
-### Changed
-### Fixed
+- Add support for Wagtail 7.3 and 7.4 LTS
+- Add support for Django 6.0
+
 ### Removed
+- Drop support for EOL Wagtail 6.3 LTS (end-of-life May 1, 2026)
+- Drop support for EOL Wagtail 7.1 (end-of-life Feb 2026)
 
 ## [9.1.0] - 2025.11.09
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
+        "Framework :: Django :: 6.0",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 6",
         "Framework :: Wagtail :: 7",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
@@ -61,7 +61,7 @@ setup(
     ],
     extras_require={"test": test_extras},
     install_requires=[
-        "Wagtail>=6.3",
+        "Wagtail>=7.0",
     ],
     project_urls={
         "Source": "https://github.com/Frojd/wagtail-geo-widget/",


### PR DESCRIPTION
## Summary
- Bump `install_requires` to `Wagtail>=7.0`; drop EOL Wagtail 6.3 LTS and Wagtail 7.1 from the CI matrix.
- Add Wagtail 7.3 and 7.4 LTS, plus Django 6.0, with the appropriate Python/Django/Wagtail exclude pairings.
- Update package classifiers (drop `Framework :: Wagtail :: 6`, add `Framework :: Django :: 6.0`) and add a CHANGELOG entry under `[Unreleased]`.
- Dev tooling: bump pinned `psf/black` action `22.3.0` → `25.1.0`; bump `lint-isort` and `publish` job Python `3.9` → `3.13`.

Target support window (sources retrieved 2026-05-12):
- Python 3.10–3.14
- Django 4.2, 5.1, 5.2, 6.0 (4.2 / 5.1 retained because Wagtail 7.0 LTS still lists them)
- Wagtail 7.0 LTS, 7.2, 7.3, 7.4 LTS (6.3 and 7.1 excluded as EOL)

Existing `WAGTAIL_VERSION >= (7, 1)` guards in `widgets.py` and `tests/test_widgets.py` are retained — Wagtail 7.0 is still the lower bound.

## Test plan
- [ ] CI matrix passes on all included Python × Django × Wagtail combinations
- [ ] `psf/black@25.1.0` lint job passes
- [ ] `isort` lint job passes on Python 3.13
- [ ] No regressions in test suite under Wagtail 7.4 LTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)